### PR TITLE
chore(contracts): remove hardfork setting

### DIFF
--- a/.changeset/yellow-pots-push.md
+++ b/.changeset/yellow-pots-push.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Test contracts against london fork

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -43,6 +43,9 @@ jobs:
         # if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      - name: Check yarn.lock for changes
+        run: git diff --exit-code
+
       - name: Build
         run: yarn build
 

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -36,7 +36,6 @@ const config: HardhatUserConfig = {
       live: false,
       saveDeployments: false,
       tags: ['local'],
-      hardfork: 'istanbul',
     },
     optimism: {
       url: 'http://127.0.0.1:8545',

--- a/packages/contracts/test/contracts/L1/messaging/L1StandardBridge.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/L1StandardBridge.spec.ts
@@ -98,12 +98,11 @@ describe('L1StandardBridge', () => {
       const initialBalance = await ethers.provider.getBalance(depositer)
 
       // alice calls deposit on the bridge and the L1 bridge calls transferFrom on the token
-      await L1StandardBridge.connect(alice).depositETH(
+      const res = await L1StandardBridge.connect(alice).depositETH(
         FINALIZATION_GAS,
         NON_NULL_BYTES32,
         {
           value: depositAmount,
-          gasPrice: 0,
         }
       )
 
@@ -111,8 +110,14 @@ describe('L1StandardBridge', () => {
         Mock__L1CrossDomainMessenger.smocked.sendMessage.calls[0]
 
       const depositerBalance = await ethers.provider.getBalance(depositer)
+      const receipt = await res.wait()
+      const depositerFeePaid =
+        receipt.cumulativeGasUsed.toNumber() *
+        receipt.effectiveGasPrice.toNumber()
 
-      expect(depositerBalance).to.equal(initialBalance.sub(depositAmount))
+      expect(depositerBalance).to.equal(
+        initialBalance.sub(depositAmount).sub(depositerFeePaid)
+      )
 
       // bridge's balance is increased
       const bridgeBalance = await ethers.provider.getBalance(
@@ -143,20 +148,26 @@ describe('L1StandardBridge', () => {
       // depositor calls deposit on the bridge and the L1 bridge calls transferFrom on the token
       const initialBalance = await ethers.provider.getBalance(aliceAddress)
 
-      await L1StandardBridge.connect(alice).depositETHTo(
+      const res = await L1StandardBridge.connect(alice).depositETHTo(
         bobsAddress,
         FINALIZATION_GAS,
         NON_NULL_BYTES32,
         {
           value: depositAmount,
-          gasPrice: 0,
         }
       )
       const depositCallToMessenger =
         Mock__L1CrossDomainMessenger.smocked.sendMessage.calls[0]
 
       const depositerBalance = await ethers.provider.getBalance(aliceAddress)
-      expect(depositerBalance).to.equal(initialBalance.sub(depositAmount))
+      const receipt = await res.wait()
+      const depositerFeePaid =
+        receipt.cumulativeGasUsed.toNumber() *
+        receipt.effectiveGasPrice.toNumber()
+
+      expect(depositerBalance).to.equal(
+        initialBalance.sub(depositAmount).sub(depositerFeePaid)
+      )
 
       // bridge's balance is increased
       const bridgeBalance = await ethers.provider.getBalance(
@@ -187,7 +198,6 @@ describe('L1StandardBridge', () => {
       expect(
         L1StandardBridge.depositETH(FINALIZATION_GAS, NON_NULL_BYTES32, {
           value: depositAmount,
-          gasPrice: 0,
         })
       ).to.be.revertedWith('Account not EOA')
     })
@@ -250,7 +260,6 @@ describe('L1StandardBridge', () => {
         NON_NULL_BYTES32,
         {
           value: ethers.utils.parseEther('1.0'),
-          gasPrice: 0,
         }
       )
 

--- a/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
@@ -25,8 +25,7 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
   let sequencer: Signer
   let alice: Signer
   before(async () => {
-    ;[sequencer] = await ethers.getSigners()
-    ;[alice] = await ethers.getSigners()
+    ;[sequencer, alice] = await ethers.getSigners()
   })
 
   let AddressManager: Contract
@@ -139,14 +138,13 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
         NON_NULL_BYTES32,
         {
           value: depositAmount,
-          gasPrice: 0,
         }
       )
 
       const receipt = await res.wait()
       const gasUsed = receipt.gasUsed.toNumber()
       console.log('    - Gas used:', gasUsed)
-      expectApprox(gasUsed, 116_781, {
+      expectApprox(gasUsed, 132_481, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -169,11 +167,10 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
         FINALIZATION_GAS,
         NON_NULL_BYTES32
       )
-
       const receipt = await res.wait()
       const gasUsed = receipt.gasUsed.toNumber()
       console.log('    - Gas used:', gasUsed)
-      expectApprox(gasUsed, 164_622, {
+      expectApprox(gasUsed, 192_822, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -157,7 +157,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_422_181, {
+      expectApprox(gasUsed, 1_402_638, {
         absoluteUpperDeviation: 1000,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -293,7 +293,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
 
       console.log('Benchmark complete.')
 
-      expectApprox(gasUsed, 189_487, {
+      expectApprox(gasUsed, 196_687, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -314,7 +314,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
 
       console.log('Benchmark complete.')
 
-      expectApprox(gasUsed, 127_500, {
+      expectApprox(gasUsed, 134_100, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!


### PR DESCRIPTION
Removes the 'hardfork' config setting, falling back to hardhat's default,
which for our current hardhat version is 'london'

fix(contracts): adjust fee math for london